### PR TITLE
A stronger adaptive core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/build/
 **/dist/
 __pycache__
+.idea

--- a/multi_train.sh
+++ b/multi_train.sh
@@ -1,5 +1,13 @@
-gpu_ids=${1:-0}
-options=${2:-0}
+gpu_ids="all"
+option=0
+
+if [ -n "$1" ]; then
+    gpu_ids=$1
+fi
+
+if [ -n "$2" ]; then
+    option=$2
+fi
 
 CUDA_DEVICE_ORDER="PCI_BUS_ID" \
-python ./occupiedgpus/core.py --gpu-ids $gpu_ids --epochs 120 --options $options
+python ./occupiedgpus/core.py --batch-size 32 --lr 1e-4 --eval-interval 3 --save-root ./runs --gpu-ids $gpu_ids  --option $option

--- a/occupiedgpus/core.py
+++ b/occupiedgpus/core.py
@@ -1,129 +1,150 @@
-r'''
+r"""
 The programming is used to occupy free memory on the corresponding GPU.
 
 Usage:
-    $ python train.py --gpu-ids 0,1,2,3 --epochs 120 --options 0
+    $ python train.py --gpu-ids 0,1,2,3 --option 0
     or
-    $ python -m occupiedgpus.core --gpu-ids 0,1,2,3 --epochs 120 --options 0
+    $ python -m occupiedgpus.core --gpu-ids 0,1,2,3 --option 0
 
-'''
+"""
 import argparse
-import pynvml
 import time
+from threading import Thread
 
+import pynvml
 import torch
 import torch.nn as nn
-
-from threading import Thread
 
 pynvml.nvmlInit()
 
 
 class ComputeThread(Thread):
-    r'''
+    r"""
     `name`: the thead name.
+    `is_forced`: to occupy the free memory forcefully.
     `target`: a callable object to be invoked by the `run()`.
     `args`: the argument tuple for the target invocation.
-    '''
+    """
 
-    def __init__(self, name, *args, target=None):
+    def __init__(self, name, is_forced, *args, target=None):
         super(ComputeThread, self).__init__()
         self.name = name
+        self.is_forced = is_forced
         self.target = target
         self._args = args
 
     def run(self):
-        print(f'starting {self.name}')
+        print(f'start {self.name}')
         try:
             self.target(*self._args)  # two arguments: x, delay
         except RuntimeError as e:
-            print(str(e))
+            if not self.is_forced:
+                print(str(e))
 
 
 def get_used_free_memory(gpu_id: int):
-    r'''
-    `used` and `free` in bytes (B): 2^30 = 1073741824
+    r"""
+    `used` and `free` in bytes (B): 2^30
 
     return: the remaining memory of the graphics card specified in GB
 
-    '''
+    """
+    GB = 1 << 30
     if gpu_id < pynvml.nvmlDeviceGetCount():
         handle = pynvml.nvmlDeviceGetHandleByIndex(gpu_id)
         mem_info = pynvml.nvmlDeviceGetMemoryInfo(handle)
-        return mem_info.used // 1073741824, mem_info.free // 1073741824
+        return mem_info.used // GB, mem_info.free // GB
     else:
         return -1, -1
 
 
 def init_args():
-    r'''
+    r"""
     Enter some fake training parameters such as epochs, gpu-id.
-    '''
+    """
 
-    parser = argparse.ArgumentParser(
-        description='sum the integers at the command line')
+    parser = argparse.ArgumentParser(description='sum the integers at the command line')
 
-    parser.add_argument(
-        '--gpu-ids', default='0', type=str,
-        help='gpu ids to be used')
+    parser.add_argument('--gpu-ids', type=str, default="all", help='gpu ids to use')
+    parser.add_argument('--batch-size', type=int, default=16, help='determines how fast the gpu takes up')
+    parser.add_argument('--option', default=0, type=int, help='whether to occupy the free memory forcibly')
 
-    parser.add_argument(
-        '--epochs', default=1000, type=int,
-        help='the number of epoch')
-
-    parser.add_argument(
-        '--options', default=0, type=int,
-        help='options: whether to occupy the free video memory forcefully'
-    )
+    parser.add_argument('--epochs', type=int, default=100)
+    parser.add_argument('--lr', type=float, default=1e-4)
+    parser.add_argument('--lrf', type=float, default=0.01)
+    parser.add_argument('--eval-interval', type=int, default=1)
+    parser.add_argument('--weights', type=str, default='./pre-trained/vit/jx_vit_base_patch16_224_in21k-e5005f0a.pth')
+    parser.add_argument('--save-root', type=str, default='./runs')
 
     args = parser.parse_args()
     return args
 
 
 class Compute(nn.Module):
-    def __init__(self, thread_id=0, delay=3):
+    def __init__(self, thread_id, delay=3):
         super(Compute, self).__init__()
         self.thread_id = thread_id
         self.delay = delay
+        self.op = nn.Sequential(
+            nn.Conv2d(3, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1)),
+            nn.Conv2d(64, 128, kernel_size=(5, 5), stride=(1, 1), padding=(2, 2)),
+            nn.Conv2d(128, 3, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1)),
+        )
+
+    @torch.no_grad()
+    def compute_single(self, x):
+        self.op(x)
 
     def forward(self, x):
         i = 0
         while True:
             time.sleep(self.delay)
-            for _ in range(3):
-                x = x @ x @ x
+            self.compute_single(x)
             i += 1
             if i == 100:
                 print(f'Thread {self.thread_id} is running.')
                 i = 0
 
 
-def allocate(gids, is_forced=False):
+def allocate(gids, delta_bs, is_forced=False):
     num_gpus, cnt = len(gids), 0
     is_allocated = {}
+    tid = 0
     while cnt != num_gpus:
-        for i, gid in enumerate(gids):
+        for gid in gids:
             if not is_allocated.get(gid, False):
                 used, free = get_used_free_memory(gid)
                 # round down. used==0 denotes the remaining memory is less than 1 GB.
                 if used != -1 and ((is_forced and free > 1) or (not is_forced and used == 0)):
-                    x = torch.randn(
-                        (2 * (free-1), 512*(256-2**abs(i-num_gpus//2)), 16, 16))
-                    x = x.to(f'cuda:{gid}')
-                    compute = Compute(thread_id=i, delay=3)
-                    compute = compute.to(f'cuda:{gid}')
-                    ComputeThread(f'Thread-{i}-GPU{gid}',
-                                  x, target=compute).start()
-                    is_allocated[gid] = True
-                    cnt += 1
+                    compute = Compute(thread_id=tid, delay=3).to(f'cuda:{gid}')
+                    bs = delta_bs
+                    try:
+                        while True:
+                            x = torch.zeros([bs, 3, 224, 224], device=f'cuda:{gid}')
+                            compute.compute_single(x)
+                            torch.cuda.empty_cache()
+                            bs += delta_bs
+                    except:
+                        torch.cuda.empty_cache()
+                        x = torch.zeros([max(bs - delta_bs, 2), 3, 224, 224], device=f'cuda:{gid}')
+                        ComputeThread(f'Thread{tid}-GPU{gid}', is_forced, x, target=compute).start()
+                        tid += 1
+                    if not is_forced:
+                        is_allocated[gid] = True
+                        cnt += 1
+        if is_forced:
+            time.sleep(30)
+    print("all allocated")
 
 
 def main():
     args = init_args()
-    try:
+    if args.gpu_ids in ["-1", "all", "a", ".", "..", "..."]:
+        gids = list(range(pynvml.nvmlDeviceGetCount()))
+    else:
         gids = list(map(int, args.gpu_ids.split(',')))
-        allocate(gids, args.options != 0)
-    except Exception as e:
-        print(str(e))
+    print("GPU IDs:", *gids)
+    allocate(gids, args.batch_size, args.option != 0)
+
 
 main()

--- a/train.sh
+++ b/train.sh
@@ -1,5 +1,13 @@
-gpu_ids=${1:-0}
-options=${2:-0}
+gpu_ids="all"
+option=0
+
+if [ -n "$1" ]; then
+    gpu_ids=$1
+fi
+
+if [ -n "$2" ]; then
+    option=$2
+fi
 
 CUDA_DEVICE_ORDER="PCI_BUS_ID" \
-python ./occupiedgpus/core.py --gpu-ids $gpu_ids --epochs 120 --options $options
+python ./occupiedgpus/core.py --batch-size 32 --lr 1e-4 --eval-interval 3 --save-root ./runs --gpu-ids $gpu_ids  --option $option


### PR DESCRIPTION
修复了原程序在某些型号显卡上出现 CUDA out of memory 的问题，原因在于 x = torch.randn((2 * (free-1), 512*(256-2**abs(i-num_gpus//2)), 16, 16)) 不能适配所有显卡

修改了 core.py：
1. 用 [batch_size, 3, 224, 224] 的 Tensor 通过卷积计算占据显存，程序每次会自动寻找爆显存的临界 batch_size；
2. 强制占卡模式下，可以无限侵蚀显存：在任何时间点，其他用户一旦释放了显存，我们的程序就可以马上占满它们，就像病毒一样；
3. 友好占卡模式效果不变